### PR TITLE
feat: reconnects on ack/nack timeouts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,12 +22,3 @@ updates:
       - "rustatian"
     assignees:
       - "rustatian"
-
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: daily
-    reviewers:
-      - "rustatian"
-    assignees:
-      - "rustatian"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+# Reason for This PR
+
+`[Author TODO: add issue # or explain reasoning.]`
+
+## Description of Changes
+
+`[Author TODO: add description of changes.]`
+
+## License Acceptance
+
+By submitting this pull request, I confirm that my contribution is made under
+the terms of the MIT license.
+
+## PR Checklist
+
+`[Author TODO: Meet these criteria.]`
+`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`
+
+- [ ] All commits in this PR are signed (`git commit -s`).
+- [ ] The reason for this PR is clearly provided (issue no. or explanation).
+- [ ] The description of changes is clear and encompassing.
+- [ ] Any required documentation changes (code and docs) are included in this PR.
+- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
+- [ ] All added/changed functionality is tested.

--- a/amqpjobs/redial.go
+++ b/amqpjobs/redial.go
@@ -18,6 +18,7 @@ func (c *Consumer) redialer() { //nolint:gocognit,gocyclo
 			select {
 			case err := <-c.notifyCloseConnCh:
 				if err == nil {
+					c.log.Debug("exited from redialer")
 					return
 				}
 
@@ -29,13 +30,16 @@ func (c *Consumer) redialer() { //nolint:gocognit,gocyclo
 
 				select {
 				case c.redialCh <- err:
+					c.log.Debug("exited from redialer")
 					return
 				default:
+					c.log.Debug("exited from redialer")
 					return
 				}
 
 			case err := <-c.notifyCloseConsumeCh:
 				if err == nil {
+					c.log.Debug("exited from redialer")
 					return
 				}
 
@@ -47,12 +51,15 @@ func (c *Consumer) redialer() { //nolint:gocognit,gocyclo
 
 				select {
 				case c.redialCh <- err:
+					c.log.Debug("exited from redialer")
 					return
 				default:
+					c.log.Debug("exited from redialer")
 					return
 				}
 			case err := <-c.notifyClosePubCh:
 				if err == nil {
+					c.log.Debug("exited from redialer")
 					return
 				}
 
@@ -64,12 +71,15 @@ func (c *Consumer) redialer() { //nolint:gocognit,gocyclo
 
 				select {
 				case c.redialCh <- err:
+					c.log.Debug("exited from redialer")
 					return
 				default:
+					c.log.Debug("exited from redialer")
 					return
 				}
 			case err := <-c.notifyCloseStatCh:
 				if err == nil {
+					c.log.Debug("redialer stopped")
 					return
 				}
 
@@ -81,12 +91,16 @@ func (c *Consumer) redialer() { //nolint:gocognit,gocyclo
 
 				select {
 				case c.redialCh <- err:
+					c.log.Debug("redialer stopped")
 					return
 				default:
+					c.log.Debug("redialer stopped")
 					return
 				}
 
 			case <-c.stopCh:
+				c.log.Debug("starting stop routine")
+
 				pch := <-c.publishChan
 				stCh := <-c.stateChan
 

--- a/amqpjobs/redial.go
+++ b/amqpjobs/redial.go
@@ -1,6 +1,7 @@
 package amqpjobs
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -13,94 +14,81 @@ import (
 // redialer used to redial to the rabbitmq in case of the connection interrupts
 func (c *Consumer) redialer() { //nolint:gocognit,gocyclo
 	go func() {
-		const op = errors.Op("rabbitmq_redial")
-
 		for {
 			select {
-			case err := <-c.notifyConnClose:
+			case err := <-c.notifyCloseConnCh:
 				if err == nil {
 					return
 				}
 
-				c.Lock()
-
-				// trash the broken publishing channel
-				<-c.publishChan
-
-				t := time.Now().UTC()
-				pipe := c.pipeline.Load().(*pipeline.Pipeline)
-
-				c.log.Error("pipeline connection was closed, redialing", zap.Error(err), zap.String("pipeline", pipe.Name()), zap.String("driver", pipe.Driver()), zap.Time("start", t))
-
-				expb := backoff.NewExponentialBackOff()
-				// set the retry timeout (minutes)
-				expb.MaxElapsedTime = c.retryTimeout
-				operation := func() error {
-					c.log.Warn("reconnecting", zap.Error(err))
-					var dialErr error
-					c.conn, dialErr = amqp.Dial(c.connStr)
-					if dialErr != nil {
-						return errors.E(op, dialErr)
-					}
-
-					c.log.Info("rabbitmq dial was succeed. trying to redeclare queues and subscribers")
-
-					// re-init connection
-					errInit := c.initRabbitMQ()
-					if errInit != nil {
-						c.log.Error("rabbitmq dial", zap.Error(errInit))
-						return errInit
-					}
-
-					// redeclare consume channel
-					var errConnCh error
-					c.consumeChan, errConnCh = c.conn.Channel()
-					if errConnCh != nil {
-						return errors.E(op, errConnCh)
-					}
-
-					// redeclare publish channel
-					pch, errPubCh := c.conn.Channel()
-					if errPubCh != nil {
-						return errors.E(op, errPubCh)
-					}
-
-					// start reading messages from the channel
-					deliv, err := c.consumeChan.Consume(
-						c.queue,
-						c.consumeID,
-						false,
-						false,
-						false,
-						false,
-						nil,
-					)
-					if err != nil {
-						return errors.E(op, err)
-					}
-
-					// put the fresh publishing channel
-					c.publishChan <- pch
-					// restart listener
-					c.listener(deliv)
-
-					c.log.Info("queues and subscribers was redeclared successfully")
-
-					return nil
+				// stopped
+				if atomic.LoadUint32(&c.stopped) == 1 {
+					c.log.Debug("redialer stopped")
+					continue
 				}
 
-				retryErr := backoff.Retry(operation, expb)
-				if retryErr != nil {
-					c.Unlock()
-					c.log.Error("backoff operation failed", zap.Error(retryErr))
+				select {
+				case c.redialCh <- err:
+					return
+				default:
 					return
 				}
 
-				c.log.Info("connection was successfully restored", zap.String("pipeline", pipe.Name()), zap.String("driver", pipe.Driver()), zap.Time("start", t), zap.Duration("elapsed", time.Since(t)))
-				c.Unlock()
+			case err := <-c.notifyCloseConsumeCh:
+				if err == nil {
+					return
+				}
+
+				// stopped
+				if atomic.LoadUint32(&c.stopped) == 1 {
+					c.log.Debug("redialer stopped")
+					continue
+				}
+
+				select {
+				case c.redialCh <- err:
+					return
+				default:
+					return
+				}
+			case err := <-c.notifyClosePubCh:
+				if err == nil {
+					return
+				}
+
+				// stopped
+				if atomic.LoadUint32(&c.stopped) == 1 {
+					c.log.Debug("redialer stopped")
+					continue
+				}
+
+				select {
+				case c.redialCh <- err:
+					return
+				default:
+					return
+				}
+			case err := <-c.notifyCloseStatCh:
+				if err == nil {
+					return
+				}
+
+				// stopped
+				if atomic.LoadUint32(&c.stopped) == 1 {
+					c.log.Debug("redialer stopped")
+					continue
+				}
+
+				select {
+				case c.redialCh <- err:
+					return
+				default:
+					return
+				}
 
 			case <-c.stopCh:
 				pch := <-c.publishChan
+				stCh := <-c.stateChan
 
 				if c.deleteQueueOnStop {
 					msg, err := pch.QueueDelete(c.queue, false, false, false)
@@ -114,6 +102,10 @@ func (c *Consumer) redialer() { //nolint:gocognit,gocyclo
 				if err != nil {
 					c.log.Error("publish channel close", zap.Error(err))
 				}
+				err = stCh.Close()
+				if err != nil {
+					c.log.Error("state channel close", zap.Error(err))
+				}
 
 				if c.consumeChan != nil {
 					err = c.consumeChan.Close()
@@ -122,14 +114,155 @@ func (c *Consumer) redialer() { //nolint:gocognit,gocyclo
 					}
 				}
 
-				err = c.conn.Close()
-				if err != nil {
-					c.log.Error("amqp connection closed", zap.Error(err))
+				if c.conn != nil {
+					err = c.conn.Close()
+					if err != nil {
+						c.log.Error("amqp connection closed", zap.Error(err))
+					}
 				}
 
-				close(c.publishChan)
 				return
 			}
 		}
 	}()
+}
+
+func (c *Consumer) reset() {
+	pch := <-c.publishChan
+	stCh := <-c.stateChan
+
+	err := pch.Close()
+	if err != nil {
+		c.log.Error("publish channel close", zap.Error(err))
+	}
+	err = stCh.Close()
+	if err != nil {
+		c.log.Error("state channel close", zap.Error(err))
+	}
+
+	if c.consumeChan != nil {
+		err = c.consumeChan.Close()
+		if err != nil {
+			c.log.Error("consume channel close", zap.Error(err))
+		}
+	}
+
+	if c.conn != nil {
+		err = c.conn.Close()
+		if err != nil {
+			c.log.Error("amqp connection closed", zap.Error(err))
+		}
+	}
+}
+
+func (c *Consumer) redialMergeCh() {
+	go func() {
+		for err := range c.redialCh {
+			c.Lock()
+			c.redial(err)
+			c.Unlock()
+		}
+	}()
+}
+
+func (c *Consumer) redial(amqpErr *amqp.Error) {
+	const op = errors.Op("rabbitmq_redial")
+	// trash the broken publishing channel
+	c.reset()
+
+	t := time.Now().UTC()
+	pipe := c.pipeline.Load().(*pipeline.Pipeline)
+
+	c.log.Error("pipeline connection was closed, redialing", zap.Error(amqpErr), zap.String("pipeline", pipe.Name()), zap.String("driver", pipe.Driver()), zap.Time("start", t))
+
+	expb := backoff.NewExponentialBackOff()
+	// set the retry timeout (minutes)
+	expb.MaxElapsedTime = c.retryTimeout
+	operation := func() error {
+		var err error
+		c.conn, err = amqp.Dial(c.connStr)
+		if err != nil {
+			return errors.E(op, err)
+		}
+
+		c.log.Info("rabbitmq dial was succeed. trying to redeclare queues and subscribers")
+
+		// re-init connection
+		err = c.initRabbitMQ()
+		if err != nil {
+			c.log.Error("rabbitmq dial", zap.Error(err))
+			return errors.E(op, err)
+		}
+
+		// redeclare consume channel
+		c.consumeChan, err = c.conn.Channel()
+		if err != nil {
+			return errors.E(op, err)
+		}
+
+		err = c.consumeChan.Qos(c.prefetch, 0, false)
+		if err != nil {
+			c.log.Error("QOS", zap.Error(err))
+			return errors.E(op, err)
+		}
+
+		// redeclare publish channel
+		pch, err := c.conn.Channel()
+		if err != nil {
+			return errors.E(op, err)
+		}
+
+		sch, err := c.conn.Channel()
+		if err != nil {
+			return errors.E(op, err)
+		}
+
+		// start reading messages from the channel
+		deliv, err := c.consumeChan.Consume(
+			c.queue,
+			c.consumeID,
+			false,
+			false,
+			false,
+			false,
+			nil,
+		)
+		if err != nil {
+			return errors.E(op, err)
+		}
+
+		c.notifyClosePubCh = make(chan *amqp.Error, 1)
+		c.notifyCloseStatCh = make(chan *amqp.Error, 1)
+		c.notifyCloseConnCh = make(chan *amqp.Error, 1)
+		c.notifyCloseConsumeCh = make(chan *amqp.Error, 1)
+
+		c.conn.NotifyClose(c.notifyCloseConnCh)
+		c.consumeChan.NotifyClose(c.notifyCloseConsumeCh)
+		pch.NotifyClose(c.notifyClosePubCh)
+		sch.NotifyClose(c.notifyCloseStatCh)
+
+		// put the fresh channels
+		c.stateChan <- sch
+		c.publishChan <- pch
+
+		// restart listener
+		atomic.StoreUint32(&c.listeners, 1)
+		c.listener(deliv)
+
+		c.log.Info("queues and subscribers was redeclared successfully")
+
+		return nil
+	}
+
+	retryErr := backoff.Retry(operation, expb)
+	if retryErr != nil {
+		c.log.Error("backoff operation failed", zap.Error(retryErr))
+		return
+	}
+
+	c.log.Info("connection was successfully restored", zap.String("pipeline", pipe.Name()), zap.String("driver", pipe.Driver()), zap.Time("start", t), zap.Duration("elapsed", time.Since(t)))
+
+	// restart redialer
+	c.redialer()
+	c.log.Info("redialer restarted")
 }


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1103

## Description of Changes

- In case of ack timeout the listener channel will be closed. This PR brings reconnect handlers to that event.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
