### PR TITLE
fix: properly parse rabbitmq prefetch

### DIFF
--- a/amqpjobs/consumer.go
+++ b/amqpjobs/consumer.go
@@ -3,6 +3,7 @@ package amqpjobs
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -181,6 +182,12 @@ func FromPipeline(pipeline *pipeline.Pipeline, log *zap.Logger, cfg cfgPlugin.Co
 	conf.InitDefault()
 	// PARSE CONFIGURATION -------
 
+	// parse prefetch
+	prf, err := strconv.Atoi(pipeline.String(prefetch, "10"))
+	if err != nil {
+		log.Error("prefetch parse, driver will use default (10) prefetch", zap.String("prefetch", pipeline.String(prefetch, "10")))
+	}
+
 	jb := &Consumer{
 		log:          log,
 		pq:           pq,
@@ -203,7 +210,7 @@ func FromPipeline(pipeline *pipeline.Pipeline, log *zap.Logger, cfg cfgPlugin.Co
 		queue:             pipeline.String(queue, "default"),
 		exchangeType:      pipeline.String(exchangeType, "direct"),
 		exchangeName:      pipeline.String(exchangeKey, "amqp.default"),
-		prefetch:          pipeline.Int(prefetch, 10),
+		prefetch:          prf,
 		priority:          int64(pipeline.Int(priority, 10)),
 		durable:           pipeline.Bool(durable, false),
 		deleteQueueOnStop: pipeline.Bool(deleteOnStop, false),


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1197

## Description of Changes

- Previously, `prefetch` was used as an `int`, but RR receives it as a `string` via RPC.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
