### PR TITLE
feat: expose more `rabbitmq` exchange/queue options

### DIFF
--- a/amqpjobs/config.go
+++ b/amqpjobs/config.go
@@ -15,6 +15,11 @@ const (
 	multipleAsk   string = "multiple_ask"
 	requeueOnFail string = "requeue_on_fail"
 
+	// new in 2.12
+	exchangeDurable    string = "exchange_durable"
+	exchangeAutoDelete string = "exchange_auto_delete"
+	queueAutoDelete    string = "queue_auto_delete"
+
 	dlx           string = "x-dead-letter-exchange"
 	dlxRoutingKey string = "x-dead-letter-routing-key"
 	dlxTTL        string = "x-message-ttl"
@@ -29,11 +34,17 @@ type config struct {
 	Addr string `mapstructure:"addr"`
 
 	// local
-	Prefetch          int    `mapstructure:"prefetch"`
-	Queue             string `mapstructure:"queue"`
-	Priority          int64  `mapstructure:"priority"`
-	Exchange          string `mapstructure:"exchange"`
-	ExchangeType      string `mapstructure:"exchange_type"`
+	Prefetch     int    `mapstructure:"prefetch"`
+	Queue        string `mapstructure:"queue"`
+	Priority     int64  `mapstructure:"priority"`
+	Exchange     string `mapstructure:"exchange"`
+	ExchangeType string `mapstructure:"exchange_type"`
+
+	// new in 2.12
+	ExchangeDurable    bool `mapstructure:"exchange_durable"`
+	ExchangeAutoDelete bool `mapstructure:"exchange_auto_delete"`
+	QueueAutoDelete    bool `mapstructure:"queue_auto_delete"`
+
 	RoutingKey        string `mapstructure:"routing_key"`
 	ConsumeAll        bool   `mapstructure:"consume_all"`
 	Exclusive         bool   `mapstructure:"exclusive"`

--- a/amqpjobs/consumer.go
+++ b/amqpjobs/consumer.go
@@ -64,6 +64,11 @@ type Consumer struct {
 	durable           bool
 	deleteQueueOnStop bool
 
+	// new in 2.12
+	exchangeDurable    bool
+	exchangeAutoDelete bool
+	queueAutoDelete    bool
+
 	listeners uint32
 	delayed   *int64
 	stopCh    chan struct{}
@@ -131,6 +136,10 @@ func NewAMQPConsumer(configKey string, log *zap.Logger, cfg Configurer, pq prior
 		exclusive:         conf.Exclusive,
 		multipleAck:       conf.MultipleAck,
 		requeueOnFail:     conf.RequeueOnFail,
+
+		exchangeAutoDelete: conf.ExchangeAutoDelete,
+		exchangeDurable:    conf.ExchangeDurable,
+		queueAutoDelete:    conf.QueueAutoDelete,
 	}
 
 	jb.conn, err = amqp.Dial(conf.Addr)
@@ -224,6 +233,11 @@ func FromPipeline(pipeline *pipeline.Pipeline, log *zap.Logger, cfg Configurer, 
 		exclusive:         pipeline.Bool(exclusive, false),
 		multipleAck:       pipeline.Bool(multipleAsk, false),
 		requeueOnFail:     pipeline.Bool(requeueOnFail, false),
+
+		// new in 2.12
+		exchangeAutoDelete: pipeline.Bool(exchangeAutoDelete, false),
+		exchangeDurable:    pipeline.Bool(exchangeAutoDelete, false),
+		queueAutoDelete:    pipeline.Bool(queueAutoDelete, false),
 	}
 
 	jb.conn, err = amqp.Dial(conf.Addr)

--- a/amqpjobs/rabbit_init.go
+++ b/amqpjobs/rabbit_init.go
@@ -18,8 +18,8 @@ func (c *Consumer) initRabbitMQ() error {
 	err = channel.ExchangeDeclare(
 		c.exchangeName,
 		c.exchangeType,
-		true,
-		false,
+		c.exchangeDurable,
+		c.exchangeAutoDelete,
 		false,
 		false,
 		nil,
@@ -32,7 +32,7 @@ func (c *Consumer) initRabbitMQ() error {
 	q, err := channel.QueueDeclare(
 		c.queue,
 		c.durable,
-		false,
+		c.queueAutoDelete,
 		c.exclusive,
 		false,
 		nil,


### PR DESCRIPTION
# Reason for This PR

- closes: https://github.com/roadrunner-server/roadrunner/issues/1351

## Description of Changes

- Expose three new options: `exchange_durable`, `exchange_auto_deleted` and `queue_auto_deleted`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
