### PR TITLE
feature: check the status of the `rabbitmq` connection

### DIFF
--- a/amqpjobs/config.go
+++ b/amqpjobs/config.go
@@ -16,6 +16,7 @@ const (
 	requeueOnFail string = "requeue_on_fail"
 
 	// new in 2.12
+	redialTimeout      string = "redial_timeout"
 	exchangeDurable    string = "exchange_durable"
 	exchangeAutoDelete string = "exchange_auto_delete"
 	queueAutoDelete    string = "queue_auto_delete"
@@ -44,6 +45,7 @@ type config struct {
 	ExchangeDurable    bool `mapstructure:"exchange_durable"`
 	ExchangeAutoDelete bool `mapstructure:"exchange_auto_delete"`
 	QueueAutoDelete    bool `mapstructure:"queue_auto_delete"`
+	RedialTimeout      int  `mapstructure:"redial_timeout"`
 
 	RoutingKey        string `mapstructure:"routing_key"`
 	ConsumeAll        bool   `mapstructure:"consume_all"`
@@ -66,6 +68,10 @@ func (c *config) InitDefault() {
 
 	if c.Queue == "" {
 		c.Queue = "default"
+	}
+
+	if c.RedialTimeout == 0 {
+		c.RedialTimeout = 60
 	}
 
 	if c.Prefetch == 0 {

--- a/amqpjobs/redial.go
+++ b/amqpjobs/redial.go
@@ -171,9 +171,9 @@ func (c *Consumer) reset() {
 func (c *Consumer) redialMergeCh() {
 	go func() {
 		for err := range c.redialCh {
-			c.Lock()
+			c.mu.Lock()
 			c.redial(err)
-			c.Unlock()
+			c.mu.Unlock()
 		}
 	}()
 }


### PR DESCRIPTION
# Reason for This PR

- ref: https://github.com/roadrunner-server/roadrunner/issues/1363
- Implement status checks of the RMQ connection.
- Move to the userspace option to specify the redial timeout.

## Description of Changes

- Use `QueueInspect` to check the connection status.
- Add new option: `redial_timeout` in seconds to specify redial timeout if RR lost the connection with the RMQ server.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
