### PR TITLE
feature: restrict empty routing key or queue name

### DIFF
--- a/amqpjobs/config.go
+++ b/amqpjobs/config.go
@@ -83,10 +83,6 @@ func (c *config) InitDefault() {
 		c.Exchange = "amqp.default"
 	}
 
-	if c.Queue == "" {
-		c.Queue = "default"
-	}
-
 	if c.RedialTimeout == 0 {
 		c.RedialTimeout = 60
 	}
@@ -101,11 +97,6 @@ func (c *config) InitDefault() {
 
 	if c.Addr == "" {
 		c.Addr = "amqp://guest:guest@127.0.0.1:5672/"
-	}
-
-	// if user doesn't specify a routing key, use queue name as routing key
-	if c.RoutingKey == "" {
-		c.RoutingKey = c.Queue
 	}
 
 	if c.ConsumerID == "" {


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1443

## Description of Changes

- Queue name or routing key are now required.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
