### PR TITLE
fix: OTEL panic on `nil` map access

### DIFF
--- a/amqpjobs/listener.go
+++ b/amqpjobs/listener.go
@@ -46,6 +46,10 @@ func (d *Driver) listener(deliv <-chan amqp.Delivery) {
 				_ = msg.Ack(false)
 			}
 
+			if del.Headers == nil {
+				del.Headers = make(map[string][]string, 2)
+			}
+
 			d.prop.Inject(ctx, propagation.HeaderCarrier(del.Headers))
 			// insert job into the main priority queue
 			d.pq.Insert(del)


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1553

## Description of Changes

1. If there are no headers in the AMQP table, make an empty map to pass to the OTEL propogator.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
