### PR TITLE
fix: add queue name to received job

### DIFF
--- a/amqpjobs/driver.go
+++ b/amqpjobs/driver.go
@@ -340,7 +340,7 @@ func (d *Driver) Push(ctx context.Context, job jobs.Job) error {
 	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(tracerName).Start(ctx, "amqp_push")
 	defer span.End()
 
-	if d.routingKey == "" {
+	if d.routingKey == "" && d.exchangeType != "fanout" {
 		return errors.Str("empty routing key, consider adding the routing key name to the AMQP configuration")
 	}
 

--- a/amqpjobs/item.go
+++ b/amqpjobs/item.go
@@ -275,6 +275,7 @@ func (d *Driver) unpack(deliv amqp.Delivery) (*Item, error) {
 			multipleAsk: d.multipleAck,
 			requeue:     d.requeueOnFail,
 			requeueFn:   d.handleItem,
+			Queue:       d.queue,
 		},
 	}
 


### PR DESCRIPTION
# Reason for This PR

`Add a queue name to Job that is sent to the jobs worker`

## Description of Changes

This PR is made for the "fanout exchange type" RabbitMQ, when a message is sent for exchange, at consume we do not know which handler should be run, because we have no information from which RabbitMQ queue the message is consumed. And disables routing key checking for the fanout exchange type

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
