### PR TITLE
listener: end span in case of error

### DIFF
--- a/amqpjobs/listener.go
+++ b/amqpjobs/listener.go
@@ -38,6 +38,7 @@ func (d *Driver) listener(deliv <-chan amqp.Delivery) {
 					del.headers = nil
 					del.Options = nil
 				}
+				span.End()
 				continue
 			}
 


### PR DESCRIPTION
# Reason for This PR

Sometimes OTEL in jobs/amqp plugin does not closed properly.

## Description of Changes

Let's close span in listener in case of error.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
