### PR TITLE
fix: error while producing messages with same delay

### DIFF
--- a/amqpjobs/conv_test.go
+++ b/amqpjobs/conv_test.go
@@ -29,6 +29,7 @@ func TestConv(t *testing.T) {
 	table["bt"] = true
 
 	table["bytes"] = []byte("fooooooobbbbbb")
+	table["decimal"] = amqp.Decimal{Scale: 4, Value: 12345}
 
 	table["foo"] = float32(2.3)
 	table["foo2"] = 2.3
@@ -51,6 +52,7 @@ func TestConv(t *testing.T) {
 	require.Equal(t, ret["i"], []string{"1"})
 	require.Equal(t, ret["g"], []string{"1"})
 	require.Equal(t, ret["k"], []string{"1"})
+	require.Equal(t, ret["decimal"], []string{"1.2345"})
 
 	require.Equal(t, ret["strsl"], []string{"a", "b", "c"})
 	require.Equal(t, ret["str"], []string{"fooooo"})

--- a/amqpjobs/driver.go
+++ b/amqpjobs/driver.go
@@ -642,7 +642,7 @@ func (d *Driver) handleItem(ctx context.Context, msg *Item) error {
 			// TODO declare separate method for this if condition
 			// TODO dlx cache channel??
 			delayMs := int64(msg.Options.DelayDuration().Seconds() * 1000)
-			tmpQ := fmt.Sprintf("delayed-%d.%s.%s", delayMs, d.exchangeName, d.queue)
+			tmpQ := fmt.Sprintf("delayed-%d.%s.%s", delayMs, d.exchangeName, d.queueOrRk())
 			_, err = pch.QueueDeclare(tmpQ, true, false, false, false, amqp.Table{
 				dlx:           d.exchangeName,
 				dlxRoutingKey: rk,
@@ -735,6 +735,14 @@ func (d *Driver) setRoutingKey(headers map[string][]string) string {
 		if len(val) == 1 && val[0] != "" {
 			return val[0]
 		}
+	}
+
+	return d.routingKey
+}
+
+func (d *Driver) queueOrRk() string {
+	if d.queue != "" {
+		return d.queue
 	}
 
 	return d.routingKey

--- a/tests/configs/.rr-amqp-bug-1792.yaml
+++ b/tests/configs/.rr-amqp-bug-1792.yaml
@@ -1,0 +1,46 @@
+version: '3'
+
+rpc:
+  listen: tcp://127.0.0.1:1792
+
+server:
+  command: "php php_test_files/jobs/jobs_ok.php"
+  relay: "pipes"
+  relay_timeout: "20s"
+
+amqp:
+  addr: amqp://guest:guest@127.0.0.1:5672/
+
+logs:
+  level: debug
+  encoding: console
+  mode: development
+
+jobs:
+  num_pollers: 1
+  pipeline_size: 100000
+  timeout: 1
+  pool:
+    num_workers: 10
+    allocate_timeout: 60s
+    destroy_timeout: 1s
+
+  pipelines:
+    queue1:
+      driver: amqp
+      config:
+        durable: true
+        exchange: amqp.direct
+        routing_key: queue1
+        queue: queue1
+        exchange_type: direct
+        exchange_durable: true
+    queue2:
+      driver: amqp
+      config:
+        durable: true
+        exchange: amqp.direct
+        routing_key: queue2
+        queue: queue2
+        exchange_type: direct
+        exchange_durable: true

--- a/tests/jobs_amqp_durability_test.go
+++ b/tests/jobs_amqp_durability_test.go
@@ -37,7 +37,7 @@ func TestDurabilityAMQP(t *testing.T) {
 	cont := endure.New(slog.LevelDebug)
 
 	cfg := &config.Plugin{
-		Version: "2.9.0",
+		Version: "2023.3.0",
 		Path:    "configs/.rr-amqp-durability-redial.yaml",
 		Prefix:  "rr",
 	}


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1792

## Description of Changes

- Use `routing key` if `queue` is empty.
- Handle additional cases when parsing headers: `amqp.Table`, `Decimal`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced message conversion to support additional data types in AMQP jobs.
  - Introduced a new configuration version for improved AMQP job handling.
  - Added a test to verify the fix for a specific AMQP-related bug.

- **Bug Fixes**
  - Adjusted queue naming logic to ensure correct routing of messages.

- **Tests**
  - Implemented new tests to validate AMQP functionality and configurations.
  - Updated existing tests to align with the new configuration version.

- **Documentation**
  - Documented the new server, AMQP, logs, and job configurations in YAML format.

- **Refactor**
  - Improved internal methods for message handling in AMQP jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->