### PR TITLE
chore: Remove legacy consume_all feature

### DIFF
--- a/amqpjobs/config.go
+++ b/amqpjobs/config.go
@@ -26,7 +26,6 @@ const (
 	exchangeType  string = "exchange_type"
 	queue         string = "queue"
 	routingKey    string = "routing_key"
-	consumeAll    string = "consume_all"
 	prefetch      string = "prefetch"
 	exclusive     string = "exclusive"
 	durable       string = "durable"
@@ -71,7 +70,6 @@ type config struct {
 	ExchangeType string `mapstructure:"exchange_type"`
 
 	RoutingKey        string `mapstructure:"routing_key"`
-	ConsumeAll        bool   `mapstructure:"consume_all"`
 	Exclusive         bool   `mapstructure:"exclusive"`
 	Durable           bool   `mapstructure:"durable"`
 	DeleteQueueOnStop bool   `mapstructure:"delete_queue_on_stop"`

--- a/amqpjobs/driver.go
+++ b/amqpjobs/driver.go
@@ -40,13 +40,12 @@ type Configurer interface {
 }
 
 type Driver struct {
-	mu         sync.RWMutex
-	log        *zap.Logger
-	pq         jobs.Queue
-	pipeline   atomic.Pointer[jobs.Pipeline]
-	consumeAll bool
-	tracer     *sdktrace.TracerProvider
-	prop       propagation.TextMapPropagator
+	mu       sync.RWMutex
+	log      *zap.Logger
+	pq       jobs.Queue
+	pipeline atomic.Pointer[jobs.Pipeline]
+	tracer   *sdktrace.TracerProvider
+	prop     propagation.TextMapPropagator
 
 	// events
 	eventsCh chan events.Event
@@ -139,12 +138,11 @@ func FromConfig(tracer *sdktrace.TracerProvider, configKey string, log *zap.Logg
 	eventBus, id := events.NewEventBus()
 
 	jb := &Driver{
-		tracer:     tracer,
-		prop:       prop,
-		log:        log,
-		pq:         pq,
-		stopCh:     make(chan struct{}, 1),
-		consumeAll: conf.ConsumeAll,
+		tracer: tracer,
+		prop:   prop,
+		log:    log,
+		pq:     pq,
+		stopCh: make(chan struct{}, 1),
 
 		// events
 		eventsCh: eventsCh,
@@ -283,7 +281,6 @@ func FromPipeline(tracer *sdktrace.TracerProvider, pipeline jobs.Pipeline, log *
 		notifyCloseStatCh:    make(chan *amqp.Error, 1),
 		notifyClosePubCh:     make(chan *amqp.Error, 1),
 
-		consumeAll:        pipeline.Bool(consumeAll, false),
 		routingKey:        pipeline.String(routingKey, ""),
 		queue:             pipeline.String(queue, ""),
 		exchangeType:      pipeline.String(exchangeType, "direct"),

--- a/schema.json
+++ b/schema.json
@@ -28,9 +28,6 @@
             "prefetch": {
               "$ref": "https://raw.githubusercontent.com/roadrunner-server/jobs/refs/heads/master/schema.json#/definitions/PipelineProperties/prefetch"
             },
-            "consume_all": {
-              "$ref": "https://raw.githubusercontent.com/roadrunner-server/jobs/refs/heads/master/schema.json#/definitions/PipelineProperties/consume_all"
-            },
             "delete_queue_on_stop": {
               "type": "boolean",
               "default": false,

--- a/tests/configs/.rr-amqp-raw.yaml
+++ b/tests/configs/.rr-amqp-raw.yaml
@@ -37,7 +37,6 @@ jobs:
         delete_queue_on_stop: true
         exchange_type: direct
         routing_key: test-raw
-        consume_all: true
 
   consume: [ "test-raw" ]
 


### PR DESCRIPTION
# Reason for This PR

The property `consume_all` was removed and no longer serves any purpose.

This PR must be merged before https://github.com/roadrunner-server/jobs/pull/135.

## Description of Changes

Removed `consume_all`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
