### PR TITLE
chore(tests): align requeue assertions with jobs/v6 outcome logging

### DIFF
--- a/tests/jobs_amqp_test.go
+++ b/tests/jobs_amqp_test.go
@@ -1498,7 +1498,8 @@ func TestAMQPJobsError(t *testing.T) {
 
 	require.Equal(t, 1, oLogger.FilterMessageSnippet("job was pushed successfully").Len())
 	require.Equal(t, 4, oLogger.FilterMessageSnippet("job processing was started").Len())
-	require.Equal(t, 4, oLogger.FilterMessageSnippet("job was processed successfully").Len())
+	require.Equal(t, 1, oLogger.FilterMessageSnippet("job was processed successfully").Len())
+	require.Equal(t, 3, oLogger.FilterMessageSnippet("job was re-queued").Len())
 	require.Equal(t, 1, oLogger.FilterMessageSnippet("pipeline was paused").Len())
 	require.Equal(t, 1, oLogger.FilterMessageSnippet("pipeline was resumed").Len())
 	require.Equal(t, 1, oLogger.FilterMessageSnippet("pipeline was stopped").Len())


### PR DESCRIPTION
jobs/v6 logs requeued attempts as "job was re-queued" and logs "job was processed successfully" only on the terminal ack. TestAMQPJobsError now expects 1 success + 3 requeues instead of 4 successes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated job-processing test expectations to reflect that failed jobs are re-queued and only successfully processed once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->